### PR TITLE
fix #144 enter key re-sends last command

### DIFF
--- a/src/Outlander/TestViewController.m
+++ b/src/Outlander/TestViewController.m
@@ -486,8 +486,13 @@
 - (IBAction)commandSubmit:(MyNSTextField*)sender {
     
     NSString *command = [sender stringValue];
-    if([command length] == 0) return;
     
+    // On enter, send previous command.
+    if([command length] == 0) {
+        [sender previousHistory];
+        command = [sender stringValue];
+    }
+
     if(command.length > 3)
         [sender commitHistory];
     


### PR DESCRIPTION
Hit ENTER, send previous command.